### PR TITLE
Fix bug for Soulbound Enchantment having no EnchantmentTarget

### DIFF
--- a/src/main/java/com/b1n4ry/yigd/core/SoulboundEnchantment.java
+++ b/src/main/java/com/b1n4ry/yigd/core/SoulboundEnchantment.java
@@ -1,12 +1,13 @@
 package com.b1n4ry.yigd.core;
 
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentTarget;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 
 public class SoulboundEnchantment extends Enchantment {
     public SoulboundEnchantment() {
-        super(Rarity.VERY_RARE, null, EquipmentSlot.values());
+        super(Rarity.VERY_RARE, EnchantmentTarget.VANISHABLE, EquipmentSlot.values());
     }
 
     public boolean isAcceptableItem(ItemStack stack) {


### PR DESCRIPTION
Fix bug for Soulbound Enchantment having no EnchantmentTarget.  This caused loot generation in some dungeon loot chests to throw an exception and not generate any loot.  Found while testing out modpack https://www.curseforge.com/minecraft/modpacks/spoornpack-fabric-1-16 and looting dungeons.  

Tested that this change allows loot to generate again