### PR TITLE
Add the ability to configure soulbound further

### DIFF
--- a/src/main/java/com/b1n_ry/yigd/Yigd.java
+++ b/src/main/java/com/b1n_ry/yigd/Yigd.java
@@ -70,7 +70,7 @@ public class Yigd implements ModInitializer {
         Registry.register(Registries.ITEM, new Identifier(MOD_ID, "grave"), new BlockItem(GRAVE_BLOCK, new FabricItemSettings()));
 
         YigdConfig config = YigdConfig.getConfig();
-        if (config.extraFeatures.customSoulboundEnchant) {
+        if (config.extraFeatures.soulbound.customSoulboundEnchant) {
             SOULBOUND_ENCHANTMENT = new SoulboundEnchantment(Enchantment.Rarity.VERY_RARE);
             Registry.register(Registries.ENCHANTMENT, new Identifier(MOD_ID, "soulbound"), SOULBOUND_ENCHANTMENT);
         }

--- a/src/main/java/com/b1n_ry/yigd/config/YigdConfig.java
+++ b/src/main/java/com/b1n_ry/yigd/config/YigdConfig.java
@@ -313,13 +313,15 @@ public class YigdConfig implements ConfigData {
     }
 
     public static class ExtraFeatures {
-        public boolean customSoulboundEnchant = true;
+        
         @ConfigEntry.Gui.CollapsibleObject
         public DeathSightConfig deathSightEnchant = new DeathSightConfig();
         @ConfigEntry.Gui.CollapsibleObject
         public GraveKeyConfig graveKeys = new GraveKeyConfig();
         @ConfigEntry.Gui.CollapsibleObject
         public ScrollConfig deathScroll = new ScrollConfig();
+        @ConfigEntry.Gui.CollapsibleObject
+        public SoulboundConfig soulbound = new SoulboundConfig();
 
         public static class DeathSightConfig {
             public boolean enabled = false;
@@ -350,6 +352,13 @@ public class YigdConfig implements ConfigData {
             public enum ClickFunction {
                 RESTORE_CONTENTS, VIEW_CONTENTS, TELEPORT_TO_LOCATION
             }
+        }
+
+        public static class SoulboundConfig {
+            public boolean customSoulboundEnchant = true;
+            public boolean isTreasure = true;
+            public boolean isAvailableForEnchantedBookOffer = true;
+            public boolean isAvailableForRandomSelection = false;
         }
     }
 

--- a/src/main/java/com/b1n_ry/yigd/enchantment/SoulboundEnchantment.java
+++ b/src/main/java/com/b1n_ry/yigd/enchantment/SoulboundEnchantment.java
@@ -5,23 +5,27 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentTarget;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
+import com.b1n_ry.yigd.config.YigdConfig;
 
 public class SoulboundEnchantment extends Enchantment {
     public SoulboundEnchantment(Rarity weight, EquipmentSlot... slotTypes) {
         super(weight, EnchantmentTarget.BREAKABLE, slotTypes);
     }
 
+    YigdConfig config = YigdConfig.getConfig();
+
     @Override
     public boolean isTreasure() {
-        return super.isTreasure();
+        return config.extraFeatures.soulbound.isTreasure;
     }
+
     @Override
     public boolean isAvailableForEnchantedBookOffer() {
-        return super.isAvailableForEnchantedBookOffer();
+        return config.extraFeatures.soulbound.isAvailableForEnchantedBookOffer;
     }
     @Override
     public boolean isAvailableForRandomSelection() {
-        return super.isAvailableForRandomSelection();
+        return config.extraFeatures.soulbound.isAvailableForRandomSelection;
     }
 
     @Override

--- a/src/main/resources/assets/yigd/lang/en_us.json
+++ b/src/main/resources/assets/yigd/lang/en_us.json
@@ -199,7 +199,6 @@
   "text.autoconfig.yigd.option.graveRendering.useGlowingEffect": "Glowing Outline Enabled?",
   "text.autoconfig.yigd.option.graveRendering.glowingDistance": "Glowing Outline Distance",
   "text.autoconfig.yigd.option.extraFeatures": "Extra Features",
-  "text.autoconfig.yigd.option.extraFeatures.customSoulboundEnchant": "Use YiGD Soulbound Enchant",
   "text.autoconfig.yigd.option.extraFeatures.deathSightEnchant": "Death Sight Enchant",
   "text.autoconfig.yigd.option.extraFeatures.deathSightEnchant.enabled": "Should Load?",
   "text.autoconfig.yigd.option.extraFeatures.deathSightEnchant.range": "Range",
@@ -214,5 +213,10 @@
   "text.autoconfig.yigd.option.extraFeatures.deathScroll.enabled": "Should Load?",
   "text.autoconfig.yigd.option.extraFeatures.deathScroll.rebindable": "Rebindable",
   "text.autoconfig.yigd.option.extraFeatures.deathScroll.receiveOnRespawn": "Receive on Respawn",
-  "text.autoconfig.yigd.option.extraFeatures.deathScroll.clickFunction": "Executed When Used"
+  "text.autoconfig.yigd.option.extraFeatures.deathScroll.clickFunction": "Executed When Used",
+  "text.autoconfig.yigd.option.extraFeatures.soulbound": "Soulbound",
+  "text.autoconfig.yigd.option.extraFeatures.soulbound.customSoulboundEnchant": "Should Load?",
+  "text.autoconfig.yigd.option.extraFeatures.soulbound.isTreasure": "Is Treasure Enchantment?",
+  "text.autoconfig.yigd.option.extraFeatures.soulbound.isAvailableForEnchantedBookOffer": "Is Tradeable from Villagers?",
+  "text.autoconfig.yigd.option.extraFeatures.soulbound.isAvailableForRandomSelection": "Appears in Enchanting Table (and loots with random enchants)?"
 }


### PR DESCRIPTION
This adds further options for users to customize their own version of soulbound, in particular it controls the various options of the enchanted book.
To make it neater, i moved soulbound into its own category for the configs, and match a similar format as with the other enchantment.
By default, soulbound is set to treasure enchant true, and villager trading true, as per your previous default configuration.

It's my first attempt at modding something here, so do correct me if i did something wrong.