### PR TITLE
[1.20 - Fabric] Fix issues with Accessories Compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ org.gradle.parallel=true
 	apoli_version=v2.9.0
 	levelz_version=1.4.13+1.20.1
 	beans_backpacks_version=bsSV8DuI
-	accessories_version=1.0.0-beta.26+1.20.1
+	accessories_version=1.0.0-beta.30+1.20.1
 
 # Dev dependencies
 	cardinal_components_version=5.2.2

--- a/src/main/java/com/b1n_ry/yigd/compat/AccessoriesCompat.java
+++ b/src/main/java/com/b1n_ry/yigd/compat/AccessoriesCompat.java
@@ -9,7 +9,6 @@ import com.b1n_ry.yigd.compat.AccessoriesCompat.AccessoriesInventorySlot;
 import io.wispforest.accessories.api.AccessoriesAPI;
 import io.wispforest.accessories.api.AccessoriesCapability;
 import io.wispforest.accessories.api.AccessoriesContainer;
-import io.wispforest.accessories.api.Accessory;
 import io.wispforest.accessories.api.slot.SlotReference;
 import io.wispforest.accessories.impl.ExpandedSimpleContainer;
 import net.minecraft.item.ItemStack;
@@ -32,10 +31,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
 
     @Override
     public void clear(ServerPlayerEntity player) {
-        AccessoriesCapability.getOptionally(player).ifPresent(inv -> inv.getContainers().forEach((s, accessoriesContainer) -> {
-            accessoriesContainer.getAccessories().clear();
-            accessoriesContainer.getCosmeticAccessories().clear();
-        }));
+        AccessoriesCapability.getOptionally(player).ifPresent(inv -> inv.reset(false));
     }
 
     @Override
@@ -51,12 +47,12 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                     // We need to check in case the drop rule is a trinket drop rule (only has one difference and that is trinkets have DEFAULT)
                     String dropRuleString = itemNbt.getString("dropRule");
                     if (dropRuleString.equals("DEFAULT")) {
-                        dropRule = YigdConfig.getConfig().compatConfig.defaultTrinketsDropRule;
+                        dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                     } else {
                         dropRule = DropRule.valueOf(dropRuleString);
                     }
                 } else {
-                    dropRule = YigdConfig.getConfig().compatConfig.defaultTrinketsDropRule;
+                    dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                 }
 
                 return new Pair<>(stack, dropRule);
@@ -68,12 +64,12 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                     // We need to check in case the drop rule is a trinket drop rule (only has one difference and that is trinkets have DEFAULT)
                     String dropRuleString = itemNbt.getString("dropRule");
                     if (dropRuleString.equals("DEFAULT")) {
-                        dropRule = YigdConfig.getConfig().compatConfig.defaultTrinketsDropRule;
+                        dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                     } else {
                         dropRule = DropRule.valueOf(dropRuleString);
                     }
                 } else {
-                    dropRule = YigdConfig.getConfig().compatConfig.defaultTrinketsDropRule;
+                    dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                 }
 
                 return new Pair<>(stack, dropRule);
@@ -160,7 +156,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
 
                     Pair<ItemStack, DropRule> currentPair = thisSlot.normal.get(i);
                     ItemStack thisStack = currentPair.getLeft();
-                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.getOrDefaultAccessory(mergingStack).canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
+                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
                         extraItems.add(currentPair.getLeft());  // Add the current item to extraItems (as it's being replaced)
                         thisSlot.normal.set(i, new Pair<>(mergingStack, mergingPair.getRight()));  // Can't be unequipped, so it's prioritized
                         continue;  // Already set the item, so we can skip the rest
@@ -184,7 +180,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
 
                     Pair<ItemStack, DropRule> currentPair = thisSlot.cosmetic.get(i);
                     ItemStack thisStack = currentPair.getLeft();
-                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.getOrDefaultAccessory(mergingStack).canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
+                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
                         extraItems.add(currentPair.getLeft());  // Add the current item to extraItems (as it's being replaced)
                         thisSlot.cosmetic.set(i, new Pair<>(mergingStack, mergingPair.getRight()));  // Can't be unequipped, so it's prioritized
                         continue;  // Already set the item, so we can skip the rest
@@ -211,8 +207,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                 for (int i = 0; i < inventorySlot.normal.size(); i++) {
                     Pair<ItemStack, DropRule> pair = inventorySlot.normal.get(i);
                     ItemStack stack = pair.getLeft();
-                    Accessory accessory = AccessoriesAPI.getOrDefaultAccessory(stack);
-                    boolean isBound = accessory.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
+                    boolean isBound = !AccessoriesAPI.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
                     if (isBound) {
                         noUnequipItems.add(stack);
                         pair.setLeft(ItemStack.EMPTY);
@@ -221,8 +216,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                 for (int i = 0; i < inventorySlot.cosmetic.size(); i++) {
                     Pair<ItemStack, DropRule> pair = inventorySlot.cosmetic.get(i);
                     ItemStack stack = pair.getLeft();
-                    Accessory accessory = AccessoriesAPI.getOrDefaultAccessory(stack);
-                    boolean isBound = !accessory.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
+                    boolean isBound = !AccessoriesAPI.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
                     if (isBound) {
                         noUnequipItems.add(stack);
                         pair.setLeft(ItemStack.EMPTY);


### PR DESCRIPTION
- Use specific reset method for clearing all accessories
- Fix incorrect compat config use within readNbt
- Use static method call on AccessoriesAPI for checking if such can be unequipped
- Fix incorrect logic for pullBindingCurseItems not being negated for Normal