### PR TITLE
[1.21 - Neoforge] Fix issues with Accessories Compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,6 +51,6 @@ mod_description=Adds graves and some other stuff to the game
 
 config_version=15.0.128
 
-accessories_version=1.0.0-beta.26+1.21
+accessories_version=1.0.0-beta.30+1.21
 curios_version=9.0.5+1.21
 travelers_backpack_version=e2aP2Euz

--- a/src/main/java/com/b1n_ry/yigd/compat/AccessoriesCompat.java
+++ b/src/main/java/com/b1n_ry/yigd/compat/AccessoriesCompat.java
@@ -9,7 +9,6 @@ import com.b1n_ry.yigd.util.DropRule;
 import io.wispforest.accessories.api.AccessoriesAPI;
 import io.wispforest.accessories.api.AccessoriesCapability;
 import io.wispforest.accessories.api.AccessoriesContainer;
-import io.wispforest.accessories.api.Accessory;
 import io.wispforest.accessories.api.slot.SlotReference;
 import io.wispforest.accessories.impl.ExpandedSimpleContainer;
 import net.minecraft.core.HolderLookup;
@@ -34,10 +33,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
 
     @Override
     public void clear(ServerPlayer player) {
-        AccessoriesCapability.getOptionally(player).ifPresent(inv -> inv.getContainers().forEach((s, accessoriesContainer) -> {
-            accessoriesContainer.getAccessories().removeAllItems();
-            accessoriesContainer.getCosmeticAccessories().removeAllItems();
-        }));
+        AccessoriesCapability.getOptionally(player).ifPresent(inv -> inv.reset(false));
     }
 
     @Override
@@ -53,12 +49,12 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                     // We need to check in case the drop rule is a trinket drop rule (only has one difference and that is trinkets have DEFAULT)
                     String dropRuleString = itemNbt.getString("dropRule");
                     if (dropRuleString.equals("DEFAULT")) {
-                        dropRule = YigdConfig.getConfig().compatConfig.defaultCuriosDropRule;
+                        dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                     } else {
                         dropRule = DropRule.valueOf(dropRuleString);
                     }
                 } else {
-                    dropRule = YigdConfig.getConfig().compatConfig.defaultCuriosDropRule;
+                    dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                 }
 
                 return new Tuple<>(stack, dropRule);
@@ -70,12 +66,12 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                     // We need to check in case the drop rule is a trinket drop rule (only has one difference and that is trinkets have DEFAULT)
                     String dropRuleString = itemNbt.getString("dropRule");
                     if (dropRuleString.equals("DEFAULT")) {
-                        dropRule = YigdConfig.getConfig().compatConfig.defaultCuriosDropRule;
+                        dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                     } else {
                         dropRule = DropRule.valueOf(dropRuleString);
                     }
                 } else {
-                    dropRule = YigdConfig.getConfig().compatConfig.defaultCuriosDropRule;
+                    dropRule = YigdConfig.getConfig().compatConfig.defaultAccessoriesDropRule;
                 }
 
                 return new Tuple<>(stack, dropRule);
@@ -162,7 +158,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
 
                     Tuple<ItemStack, DropRule> currentPair = thisSlot.normal.get(i);
                     ItemStack thisStack = currentPair.getA();
-                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.getOrDefaultAccessory(mergingStack).canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
+                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
                         extraItems.add(currentPair.getA());  // Add the current item to extraItems (as it's being replaced)
                         thisSlot.normal.set(i, new Tuple<>(mergingStack, mergingPair.getB()));  // Can't be unequipped, so it's prioritized
                         continue;  // Already set the item, so we can skip the rest
@@ -186,7 +182,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
 
                     Tuple<ItemStack, DropRule> currentPair = thisSlot.cosmetic.get(i);
                     ItemStack thisStack = currentPair.getA();
-                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.getOrDefaultAccessory(mergingStack).canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
+                    if (YigdConfig.getConfig().graveConfig.treatBindingCurse && !AccessoriesAPI.canUnequip(mergingStack, SlotReference.of(merger, key, i))) {
                         extraItems.add(currentPair.getA());  // Add the current item to extraItems (as it's being replaced)
                         thisSlot.cosmetic.set(i, new Tuple<>(mergingStack, mergingPair.getB()));  // Can't be unequipped, so it's prioritized
                         continue;  // Already set the item, so we can skip the rest
@@ -213,8 +209,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                 for (int i = 0; i < inventorySlot.normal.size(); i++) {
                     Tuple<ItemStack, DropRule> pair = inventorySlot.normal.get(i);
                     ItemStack stack = pair.getA();
-                    Accessory accessory = AccessoriesAPI.getOrDefaultAccessory(stack);
-                    boolean isBound = !accessory.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
+                    boolean isBound = !AccessoriesAPI.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
                     if (isBound) {
                         noUnequipItems.add(stack);
                         pair.setA(ItemStack.EMPTY);
@@ -223,8 +218,7 @@ public class AccessoriesCompat implements InvModCompat<Map<String, AccessoriesIn
                 for (int i = 0; i < inventorySlot.cosmetic.size(); i++) {
                     Tuple<ItemStack, DropRule> pair = inventorySlot.cosmetic.get(i);
                     ItemStack stack = pair.getA();
-                    Accessory accessory = AccessoriesAPI.getOrDefaultAccessory(stack);
-                    boolean isBound = !accessory.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
+                    boolean isBound = !AccessoriesAPI.canUnequip(stack, SlotReference.of(playerRef, entry.getKey(), i));
                     if (isBound) {
                         noUnequipItems.add(stack);
                         pair.setA(ItemStack.EMPTY);


### PR DESCRIPTION
- Use specific reset method for clearing all accessories
- Fix incorrect compat config use within readNbt
- Use static method call on AccessoriesAPI for checking if such can be unequipped
- Fix incorrect logic for pullBindingCurseItems not being negated for Normal