### PR TITLE
Add `spectrum:deeper_down` min-y to GraveConfig

### DIFF
--- a/src/main/java/com/b1n_ry/yigd/config/GraveConfig.java
+++ b/src/main/java/com/b1n_ry/yigd/config/GraveConfig.java
@@ -55,6 +55,7 @@ public class GraveConfig {
         add(new MapEntryConfig.IntType("minecraft:overworld", -60));
         add(new MapEntryConfig.IntType("minecraft:the_nether", 3));
         add(new MapEntryConfig.IntType("minecraft:the_end", 3));
+        add(new MapEntryConfig.IntType("spectrum:deeper_down", -316));
         add(new MapEntryConfig.IntType("misc", 3));
     }};
     // Weather or not the grave can generate outside the world border


### PR DESCRIPTION
Spectrum'd dimension is themed as being below bedrock, thus having y levels from -65 to -320.
In the default YIGD configuration, the graves will often times spawn in inaccessible positions above the topmost bedrock ceiling, making players unable to access their graves entirely.

This PR specifies a sensible min-y level for that modded dimension, making graves show up accessible to players.